### PR TITLE
Updates to JavaDoc Instructions

### DIFF
--- a/src/test/java/lessonA_CreatingObservableStreams.java
+++ b/src/test/java/lessonA_CreatingObservableStreams.java
@@ -136,7 +136,7 @@ public class lessonA_CreatingObservableStreams {
      * So if we are going to build an observable and not subscribe to it until later on, how can we include the all
      * of the functionality as before? Do we have to put all the work inside subscribe() ? No we don't!
      * <p>
-     * If we peek at the Observer interface we see it has three methods:
+     * If we peek at the {@link rx.Observer} interface we see it has three methods:
      * <p>
      * public interface Observer<T> {
      * void onCompleted();

--- a/src/test/java/lessonB_MapAndFlatMapAndBasicOperators.java
+++ b/src/test/java/lessonB_MapAndFlatMapAndBasicOperators.java
@@ -90,9 +90,13 @@ public class lessonB_MapAndFlatMapAndBasicOperators {
         /** Was the result above what you expected? A bit strange huh? You'd think that you'd get
          * a value matching the number of items of foods in each list at first glance.
          * The reason we get a different result is because of the difference between map(), and flatmap(), which we will see next.
+         *
          * map() will always keep the SAME NUMBER OF events/ data as the previous segment in the pipeline. It can never change the number
          * of items on the previous piece of the pipeline.
-
+         *
+         * In other words, our call to map() applies a function to each item in the foodcartItemsObservable.
+         * Within this function, we return Observable(s), of type carnivalFood, for each item in our foodcartItemsObservable.
+         *
          * Next, we would like to begin filtering the list to match what we can afford to eat.
          * The problem now is that rather than Observable<Food> items, we are emitting Observable<Observable<Food>>s instead.
          * We can't filter these, because Observable has no price (its content does, but we cant access that).

--- a/src/test/java/lessonC_BooleanLogicAndErrorHandling.java
+++ b/src/test/java/lessonC_BooleanLogicAndErrorHandling.java
@@ -73,8 +73,10 @@ public class lessonC_BooleanLogicAndErrorHandling {
          *
          * Riddle: Lets define our elevator rule: the total weight of all passengers aboard an elevator may not be larger than 500 pounds.
          * How!?!
-         * Hint: Check out the Public methods available on LessonResources.Elevator and passenger!
-         */
+         *
+         * Hint: Check out the Public methods available on
+         * {@link LessonResources.Elevator} and {@link LessonResources.ElevatorPassenger}!
+         * */
 
         Func1<ElevatorPassenger, Boolean> elevatorRule = passenger -> ____ + ____ < ____;
         /**

--- a/src/test/java/lessonC_BooleanLogicAndErrorHandling.java
+++ b/src/test/java/lessonC_BooleanLogicAndErrorHandling.java
@@ -106,6 +106,8 @@ public class lessonC_BooleanLogicAndErrorHandling {
          */
         mSubscriber = new TestSubscriber<>();
         //
+        // Lets start by emptying our elevator
+        // elevator.unload();
         // ???
         //
         // assertThat(mSubscriber.getOnNextEvents()).hasSize(3);

--- a/src/test/java/lessonD_AdvancedStreams.java
+++ b/src/test/java/lessonD_AdvancedStreams.java
@@ -14,14 +14,14 @@ public class lessonD_AdvancedStreams {
     private String mEvenNums = "";
     private String mOddNums = "";
 
-    /*
-    So far everything has been pretty linear. Our pipelines all took the form:
-    "do this, then do this, then do this, then end". In reality we can combine pipelines. We can take two streams
-    and turn them into a single stream.
-
-    Now its worth nothing this is different from what we did when we nested Observables. In that case we always had one stream.
-    Lets take a stream of integers and a stream of strings and join them.
-    */
+    /**
+     * So far everything has been pretty linear. Our pipelines all took the form:
+     * "do this, then do this, then do this, then end". In reality we can combine pipelines. We can take two streams
+     * and turn them into a single stream.
+     *
+     * Now its worth nothing this is different from what we did when we nested Observables. In that case we always had one stream.
+     * Lets take a stream of integers and a stream of strings and join them.
+     */
     @Test
     public void _1_merging() {
         Observable<Object> you = Observable.just(1, 2, 3);
@@ -32,15 +32,15 @@ public class lessonD_AdvancedStreams {
         assertThat(mReceived).isEqualTo(_____);
     }
 
-    /*
-    We can also split up a single stream into two streams. We are going to to use the groupBy() action.
-    This action can be a little tricky because it emits an observable of observables. So we need to subscribe to the
-    "parent" observable and each emitted observable.
-
-    We encourage you to read more from the wiki: http://reactivex.io/documentation/operators/groupby.html
-
-    Lets split up a single stream of integers into two streams: even and odd numbers.
-    */
+    /**
+     * We can also split up a single stream into two streams. We are going to to use the groupBy() action.
+     * This action can be a little tricky because it emits an observable of observables. So we need to subscribe to the
+     * "parent" observable and each emitted observable.
+     *
+     * We encourage you to read more from the wiki: http://reactivex.io/documentation/operators/groupby.html
+     *
+     * Lets split up a single stream of integers into two streams: even and odd numbers.
+     */
     @Test
     public void _2_splittingUp() {
         Observable.range(1, 9)
@@ -62,12 +62,12 @@ public class lessonD_AdvancedStreams {
     }
 
 
-    /*
-    Lets take what we know now and do some cool stuff. We've setup an observable and a function for you. Lets combine
-    them together to average some numbers.
-
-    Also see that we need to subscribe first to the "parent" observable but that the pipeline still cold until we
-    subscribe to each subset observable. Don't forget to do that.
+    /**
+     * Lets take what we know now and do some cool stuff. We've setup an observable and a function for you. Lets combine
+     * them together to average some numbers.
+     *
+     * Also see that we need to subscribe first to the "parent" observable but that the pipeline still cold until we
+     * subscribe to each subset observable. Don't forget to do that.
      */
     @Test
     public void _3_challenge_needToSubscribeImmediatelyWhenSplitting() {

--- a/src/test/java/lessonD_AdvancedStreams.java
+++ b/src/test/java/lessonD_AdvancedStreams.java
@@ -33,7 +33,7 @@ public class lessonD_AdvancedStreams {
     }
 
     /**
-     * We can also split up a single stream into two streams. We are going to to use the groupBy() action.
+     * We can also split up a single stream into two streams. We are going to use the groupBy() action.
      * This action can be a little tricky because it emits an observable of observables. So we need to subscribe to the
      * "parent" observable and each emitted observable.
      *

--- a/src/test/java/lessonD_AdvancedStreams.java
+++ b/src/test/java/lessonD_AdvancedStreams.java
@@ -19,7 +19,7 @@ public class lessonD_AdvancedStreams {
      * "do this, then do this, then do this, then end". In reality we can combine pipelines. We can take two streams
      * and turn them into a single stream.
      *
-     * Now its worth nothing this is different from what we did when we nested Observables. In that case we always had one stream.
+     * Now its worth noting this is different from what we did when we nested Observables. In that case we always had one stream.
      * Lets take a stream of integers and a stream of strings and join them.
      */
     @Test

--- a/src/test/java/solutions/lessonB_Solutions.java
+++ b/src/test/java/solutions/lessonB_Solutions.java
@@ -190,6 +190,7 @@ public class lessonB_Solutions {
                 .subscribe();
         assertThat(mStringA).isEqualTo("123456");
         assertThat(mStringB).isEqualTo("246");
+        //assertThat(mStringC).isEqualTo("112233445566"); // Uncommenting this will produce errors
     }
 
     /**


### PR DESCRIPTION
## What was done?

- Updates to the lessonD... instructions to use javaDocs - for consistency with previous lessons - over block comments
- Added links to referenced (i.e. talked about) methods/classes/interfaces. You can click on the link instead of having to navigate to the class file manually 
- Further explained a usage of map within lessonB... . Felt this was necessary, as someone fairly new to this might have a hard time understanding what exactly is going on. 
 

